### PR TITLE
fix issue with timestamp being overwritten

### DIFF
--- a/lib/tmj_formatter/version.rb
+++ b/lib/tmj_formatter/version.rb
@@ -1,3 +1,3 @@
 module TMJFormatter
-  VERSION = '0.1.29'.freeze
+  VERSION = '0.1.30'.freeze
 end

--- a/lib/tmj_result_formatter.rb
+++ b/lib/tmj_result_formatter.rb
@@ -17,7 +17,7 @@ class TMJResultFormatter < RSpec::Core::Formatters::BaseFormatter
       @test_cases = @client.TestCase.retrive_based_on_username(test_run_data, TMJFormatter.config.username.downcase)
     end
 
-    @time_stamp = Time.now.to_i.to_s
+    @time_stamp = "#{Time.now.to_i.to_s}-#{rand(10**10)}"
     @test_results = {}
     @test_data = []
     Dir.mkdir('test_results') unless Dir.exist?('test_results')


### PR DESCRIPTION
It appeares that in some cases timestamp value may not be uniq. Added random number to the end of timestamp. 
I could get rid of `Time.now` part, but I thought it might be useful to keep the order